### PR TITLE
Some status changes

### DIFF
--- a/src/api/check.rs
+++ b/src/api/check.rs
@@ -19,7 +19,7 @@ async fn check(db: Database, check_request: Json<CheckRequest>, id: &str) -> sta
                 Ok(_) => {
                     return status::Custom(
                         Status::Accepted,
-                        json!({ "message": {"status": "ok"} }));
+                        json!({ "message": "ok" }));
                 }
                 Err(error) => {
                     return status::Custom(

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -35,7 +35,7 @@ impl AuthenticatorErrors {
             AuthenticatorErrors::InvalidId => Status::NotFound,
             AuthenticatorErrors::InvalidToken => Status::Forbidden,
             AuthenticatorErrors::BlockchainError => Status::ServiceUnavailable,
-            AuthenticatorErrors::NotStoredBlockchain => Status::NotFound,
+            AuthenticatorErrors::NotStoredBlockchain => Status::Forbidden,
             AuthenticatorErrors::MismatchedPolicies => Status::Forbidden,
             AuthenticatorErrors::ExpiredPolicy => Status::Forbidden,
             AuthenticatorErrors::InvalidSignature => Status::Forbidden,


### PR DESCRIPTION
- change  {"status": "ok"} to "ok" so it's consistent with other messages
- NotStoredBlockchain is more close to Forbidden (or maybe unauthenticated?) instead of NotFound